### PR TITLE
Feature/#125 prevent sword spam

### DIFF
--- a/src/components/objects/Ball.js
+++ b/src/components/objects/Ball.js
@@ -78,16 +78,13 @@ export default class Ball extends Phaser.Physics.Arcade.Sprite {
     //the velocity changes for hitting the player
     else {
       if (!player.isInvincible) {
-        
         player.setTemporaryInvincibility();
-        
+
         //takes away a life since the player was hit
         this.config.scene.registry.set(
           'lives',
           this.config.scene.registry.list.lives - 1
         );
-
-        player.setTemporaryInvincibility();
       }
 
       this.changeVelocX(200, 5, ball, player);

--- a/src/components/objects/Bullet.js
+++ b/src/components/objects/Bullet.js
@@ -23,11 +23,11 @@ export default class Bullet extends Phaser.Physics.Arcade.Sprite {
   }
 
   fire(x, y) {
-    if (!this.player.bulletsOnCooldown) {
+    if (!this.player.fireButtonDown) {
       this.setPosition(x, y);
       this.setActive(true);
       this.setVisible(true);
-      this.player.triggerBulletCooldown();
+      this.player.fireButtonDown = true;
     }
   }
 

--- a/src/components/objects/Player.js
+++ b/src/components/objects/Player.js
@@ -17,7 +17,7 @@ export default class Player extends Phaser.GameObjects.Sprite {
     this.slideTimer = 100;
     this.slideDistance = 250;
     this.jumpDistance = -330;
-    this.bulletsOnCooldown = false;
+    this.fireButtonDown = false;
     this.attackButtonDown = false;
     this.isInvincible = false;
   }
@@ -48,7 +48,8 @@ export default class Player extends Phaser.GameObjects.Sprite {
       fire: keys.fire.isDown || pad.buttons[1].pressed,
       bomb: keys.bomb.isDown || pad.buttons[3].pressed,
       esc: keys.esc.isDown || pad.buttons[9].pressed,
-      attackIsUp: keys.attack.isUp
+      attackIsUp: keys.attack.isUp,
+      fireIsUp: keys.fire.isUp
     };
 
     // ===== Attack Up if no arrow keys are pressed while attacking ===== //
@@ -61,6 +62,10 @@ export default class Player extends Phaser.GameObjects.Sprite {
 
     if (input.attackIsUp) {
       this.attackButtonDown = false;
+    }
+
+    if (input.fireIsUp) {
+      this.fireButtonDown = false;
     }
 
     // ===== Move left ===== //

--- a/src/components/objects/Player.js
+++ b/src/components/objects/Player.js
@@ -1,5 +1,5 @@
 import Bullet from './Bullet';
-import { checkGamepad } from '../../util/constants'
+import { checkGamepad } from '../../util/constants';
 
 export default class Player extends Phaser.GameObjects.Sprite {
   constructor(config) {
@@ -18,6 +18,7 @@ export default class Player extends Phaser.GameObjects.Sprite {
     this.slideDistance = 250;
     this.jumpDistance = -330;
     this.bulletsOnCooldown = false;
+    this.attackButtonDown = false;
     this.isInvincible = false;
   }
 
@@ -46,14 +47,20 @@ export default class Player extends Phaser.GameObjects.Sprite {
         keys.attack.isDown || pad.buttons[2].pressed || pad.buttons[6].pressed,
       fire: keys.fire.isDown || pad.buttons[1].pressed,
       bomb: keys.bomb.isDown || pad.buttons[3].pressed,
-      esc: keys.esc.isDown || pad.buttons[9].pressed
+      esc: keys.esc.isDown || pad.buttons[9].pressed,
+      attackIsUp: keys.attack.isUp
     };
 
     // ===== Attack Up if no arrow keys are pressed while attacking ===== //
-    if (!input.left && !input.right && input.attack) {
+    if (!input.left && !input.right && input.attack && !this.attackButtonDown) {
       this.anims.play('sword', true);
       this.isAttackingUp = true;
       this.on('animationcomplete', () => (this.isAttackingUp = false), this);
+      this.attackButtonDown = true;
+    }
+
+    if (input.attackIsUp) {
+      this.attackButtonDown = false;
     }
 
     // ===== Move left ===== //


### PR DESCRIPTION
Prevent player from spamming attacks or from endlessly firing bullets by holding down attack/fire buttons.
Closes #125 