### PR TITLE
Refactor/#200 bullet shower

### DIFF
--- a/src/components/objects/Bullet.js
+++ b/src/components/objects/Bullet.js
@@ -9,7 +9,7 @@ export default class Bullet extends Phaser.Physics.Arcade.Sprite {
     this.player = this.scene.player;
     this.scene.physics.world.enable(this);
 
-    this.scene.physics.add.collider(
+    this.scene.physics.add.overlap(
       this,
       this.scene.ball,
       this.hitBall,

--- a/src/scenes/Level_1.js
+++ b/src/scenes/Level_1.js
@@ -51,6 +51,7 @@ export class Level_1 extends Scene {
     this.bulletShowerCooldownTimer;
     this.bulletShowerCycle = 0;
     this.bulletShowerAngle;
+    this.bulletShowerDelay;
   }
 
   create() {
@@ -59,12 +60,19 @@ export class Level_1 extends Scene {
     //makes music accessible to the scene
     musicAdder(this);
 
+    this.bulletShowerDelay = this.registry.list.bulletShowerDelay
+      ? this.registry.list.bulletShowerDelay
+      : 5000;
+
     // ===== Level Variables ===== //
     this.gameStart = true;
     this.amountBricks = 0; //will later contain the number of bricks
     this.isPlayerAlive = true;
 
     if (this.registry.list.sessionAlive) {
+      if (this.bulletShowerDelay > 1500) {
+        this.registry.set('bulletShowerDelay', this.bulletShowerDelay - 350);
+      }
       this.lives = this.registry.list.lives;
     } else {
       this.lives = 5;
@@ -188,9 +196,8 @@ export class Level_1 extends Scene {
       (this.amountBricks === 0 && this.isPlayerAlive)
     ) {
       this.events.emit('pauseTimer');
-      if (this.bulletShowerTimer) {
-        this.bulletShowerTimer.paused = true;
-      }
+      this.bulletShowerTriggered = false;
+      this.bulletShowerTimer.destroy();
       gameOver.call(this);
     }
 
@@ -223,7 +230,7 @@ export class Level_1 extends Scene {
       }
     }
 
-    if (this.registry.list.TIMER[3] === 1 && !this.bulletShowerTriggered) {
+    if (this.registry.list.TIMER[1] === 1 && !this.bulletShowerTriggered) {
       this.triggerBulletShower();
     }
   }
@@ -247,10 +254,23 @@ export class Level_1 extends Scene {
     */
     const numRows = this.bulletShowerAngle === 1 ? 11 : 10;
     for (let i = 0; i < numRows; i++) {
-      const startX = section * i + (this.bulletShowerAngle === 0 ? 0 : this.bulletShowerAngle === 1 ? section / 2 : section);
+      const startX =
+        section * i +
+        (this.bulletShowerAngle === 0
+          ? 0
+          : this.bulletShowerAngle === 1
+            ? section / 2
+            : section);
 
       // Change the direction in which the bullet is fired based on the angle.
-      const targetX = startX + section * (this.bulletShowerAngle === 2 ? -1 : this.bulletShowerAngle === 0 ? 1 : 0);
+      const targetX =
+        startX +
+        section *
+          (this.bulletShowerAngle === 2
+            ? -1
+            : this.bulletShowerAngle === 0
+              ? 1
+              : 0);
 
       this.fireEnemyBullet(startX, 0, targetX);
     }
@@ -261,7 +281,7 @@ export class Level_1 extends Scene {
       this.bulletShowerCycle = 0;
       setTimeout(() => {
         this.resumeBulletShower();
-      }, 5000);
+      }, this.bulletShowerDelay);
     }
   }
 
@@ -298,6 +318,5 @@ export class Level_1 extends Scene {
     */
 
     this.bulletShowerAngle = Math.floor(Math.random() * 3);
-    console.log(this.bulletShowerAngle);
   }
 }

--- a/src/scenes/Level_1.js
+++ b/src/scenes/Level_1.js
@@ -45,10 +45,12 @@ export class Level_1 extends Scene {
     //starts always at 1
     this.backgroundArrayIndex = 1;
 
+    // Define variables for controlling the bullet shower
     this.bulletShowerTriggered = false;
     this.bulletShowerTimer;
     this.bulletShowerCooldownTimer;
     this.bulletShowerCycle = 0;
+    this.bulletShowerAngle;
   }
 
   create() {
@@ -221,7 +223,7 @@ export class Level_1 extends Scene {
       }
     }
 
-    if (this.registry.list.TIMER[1] === 1 && !this.bulletShowerTriggered) {
+    if (this.registry.list.TIMER[3] === 1 && !this.bulletShowerTriggered) {
       this.triggerBulletShower();
     }
   }
@@ -234,16 +236,23 @@ export class Level_1 extends Scene {
   }
 
   createBulletShower() {
-    const section = WIDTH / 2 / 3;
-    for (let i = 0; i < 3; i++) {
-      const startX_left = section * i;
-      const targetX_left = startX_left + section;
+    // Set the spacing for each row of the bullet shower
+    const section = WIDTH / 10;
 
-      const startX_right = WIDTH - section * i;
-      const targetX_right = startX_right - section;
+    /* 
+      Set the number of rows for the bullet shower.
+      Showers fired straight down require an extra row or
+      they become to easier to dodge on the left side of the 
+      screen
+    */
+    const numRows = this.bulletShowerAngle === 1 ? 11 : 10;
+    for (let i = 0; i < numRows; i++) {
+      const startX = section * i + (this.bulletShowerAngle === 0 ? 0 : this.bulletShowerAngle === 1 ? section / 2 : section);
 
-      this.fireEnemyBullet(startX_left, 0, targetX_left);
-      this.fireEnemyBullet(startX_right, 0, targetX_right);
+      // Change the direction in which the bullet is fired based on the angle.
+      const targetX = startX + section * (this.bulletShowerAngle === 2 ? -1 : this.bulletShowerAngle === 0 ? 1 : 0);
+
+      this.fireEnemyBullet(startX, 0, targetX);
     }
 
     this.bulletShowerCycle++;
@@ -256,8 +265,12 @@ export class Level_1 extends Scene {
     }
   }
 
+  /* 
+    Create the time event for the bullet shower and 
+  */
   triggerBulletShower() {
     this.bulletShowerTriggered = true;
+    this.setWaveAngle();
 
     this.bulletShowerTimer = this.time.addEvent({
       delay: 800,
@@ -272,6 +285,19 @@ export class Level_1 extends Scene {
   }
 
   resumeBulletShower() {
+    this.setWaveAngle();
     this.bulletShowerTimer.paused = false;
+  }
+
+  setWaveAngle() {
+    /* 
+      Set angle of bullet shower to one of three options:
+       - 0: Left-to-right
+       - 1: No angle (straight down)
+       - 2: Right-to-left
+    */
+
+    this.bulletShowerAngle = Math.floor(Math.random() * 3);
+    console.log(this.bulletShowerAngle);
   }
 }

--- a/src/scenes/Level_1.js
+++ b/src/scenes/Level_1.js
@@ -197,7 +197,9 @@ export class Level_1 extends Scene {
     ) {
       this.events.emit('pauseTimer');
       this.bulletShowerTriggered = false;
-      this.bulletShowerTimer.destroy();
+      if (this.bulletShowerTimer) {
+        this.bulletShowerTimer.destroy();
+      }
       gameOver.call(this);
     }
 


### PR DESCRIPTION
Fire off each cycle of the bullet shower randomly in one of three directions: left-to-right, straight down, or right-to-left. Decrease the delay between bullet shower waves by 350ms on each level until it reaches a minimum of 1500ms. Use `overlap` to detect collisions between ball and bullets instead of `collider`
Closes #200 
Closes #207 